### PR TITLE
fix: allow pass through of node env without setting target to node

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,9 +5,11 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = {
   devtool: 'source-map',
-  target: 'node',
   optimization: {
     nodeEnv: false,
+  },
+  node: {
+    process: false,
   },
   entry: './src/index.js',
   output: {


### PR DESCRIPTION
Changing the webpack target to `node` is unneeded to pass through NODE_ENV from a consuming app. This approach is better and discussed here: https://github.com/webpack/webpack/issues/6673