### PR TITLE
refactor: add comment for logInfo in errors

### DIFF
--- a/src/NewRelicLoggingService.js
+++ b/src/NewRelicLoggingService.js
@@ -74,6 +74,7 @@ class NewRelicLoggingService {
       };
       updatedCustomAttributes = Object.assign({}, requestAttributes, customAttributes);
 
+      // These are typically client-side errors, like "Network Error", that we can't do anything about.
       this.logInfo(
         `API request failed: ${request.status} ${requestMethod} ${requestUrl} ${errorMessage}`,
         updatedCustomAttributes,


### PR DESCRIPTION
Better explain why we are using logInfo for certain errors inside logAPIErrorResponse.