### PR TITLE
feat: update logging of axios errors

### DIFF
--- a/src/NewRelicLoggingService.js
+++ b/src/NewRelicLoggingService.js
@@ -40,44 +40,78 @@ class NewRelicLoggingService {
     }
   }
 
+  static processAxiosError(error = {}) {
+    const { request, response } = error;
+
+    if (response) {
+      const { status, config, data } = response;
+      const url = config ? config.url : '';
+      const stringifiedData = data ? JSON.stringify(data) : '';
+      const responseIsHTML = stringifiedData.includes('<!DOCTYPE html>');
+
+      return {
+        errorType: 'api-response-error',
+        errorStatus: status || '',
+        errorUrl: url,
+        // Don't include data if it is just an HTML document, like a 500 error page.
+        errorData: responseIsHTML ? '<Response is HTML>' : stringifiedData,
+      };
+    }
+
+    if (request) {
+      const { config, message } = error;
+      const { responseText, responseURL, status } = request;
+      const url = responseURL || (config && config.url);
+      const data = responseText || message;
+      const method = config ? config.method : '';
+
+      return {
+        errorType: 'api-request-error',
+        errorStatus: status || '',
+        errorUrl: url || '',
+        errorData: data || '',
+        errorMethod: method || '',
+      };
+    }
+
+    return {
+      errorType: 'api-request-config-error',
+      errorData: error.message || '',
+    };
+  }
+
   // API errors look for axios API error format.
   // Note: function will simply log errors that don't seem to be API error responses.
-  static logAPIErrorResponse(error, customAttributes) {
-    let processedError = error;
-    let updatedCustomAttributes = customAttributes;
+  static logAxiosError(error = {}, _customAttributes = {}) {
+    const processedError = this.processAxiosError(error);
+    const { messagePrefix, ...customAttributes } = _customAttributes;
+    const {
+      errorType,
+      errorStatus: status,
+      errorMethod: method,
+      errorUrl: url,
+      errorData: data,
+    } = processedError;
+    let message;
 
-    if (error.response) {
-      let data = !error.response.data ? '' : JSON.stringify(error.response.data);
-      // Don't include data if it is just an HTML document, like a 500 error page.
-      data = data.includes('<!DOCTYPE html>') ? '' : data;
-      const responseAttributes = {
-        errorType: 'api-response-error',
-        errorStatus: error.response.status,
-        errorUrl: error.response.config ? error.response.config.url : '',
-        errorData: data,
-      };
-      updatedCustomAttributes = Object.assign({}, responseAttributes, customAttributes);
-      processedError = new Error(`API request failed: ${error.response.status} ${responseAttributes.errorUrl} ${data}`);
+    switch (errorType) {
+      case 'api-response-error':
+        message = messagePrefix ?
+          `${messagePrefix}: (API request failed) ${status} ${url} ${data}` :
+          `API request failed: ${status} ${url} ${data}`;
 
-      this.logError(processedError, updatedCustomAttributes);
-    } else if (error.request) {
-      const { config, request } = error;
-      const errorMessage = request.responseText || error.message;
-      const requestMethod = config && config.method;
-      const requestUrl = request.responseURL || (config && config.url);
-      const requestAttributes = {
-        errorType: 'api-request-error',
-        errorStatus: request.status,
-        errorMethod: requestMethod,
-        errorUrl: requestUrl,
-        errorData: errorMessage,
-      };
-      updatedCustomAttributes = Object.assign({}, requestAttributes, customAttributes);
+        this.logError(new Error(message), { ...processedError, ...customAttributes });
+        break;
+      case 'api-request-error':
+        message = messagePrefix ?
+          `${messagePrefix}: API request failed: ${status} ${method} ${url} ${data}` :
+          `API request failed: ${status} ${method} ${url} ${data}`;
 
-      this.logInfo(
-        `API request failed: ${request.status} ${requestMethod} ${requestUrl} ${errorMessage}`,
-        updatedCustomAttributes,
-      );
+        this.logInfo(message, { ...processedError, ...customAttributes });
+        break;
+      /* istanbul ignore next */
+      default:
+        break;
     }
   }
 }

--- a/src/NewRelicLoggingService.js
+++ b/src/NewRelicLoggingService.js
@@ -40,7 +40,7 @@ class NewRelicLoggingService {
     }
   }
 
-  static processAxiosError(error = {}) {
+  static processApiClientError(error = {}) {
     const { request, response } = error;
 
     if (response) {
@@ -82,8 +82,8 @@ class NewRelicLoggingService {
 
   // API errors look for axios API error format.
   // Note: function will simply log errors that don't seem to be API error responses.
-  static logAxiosError(error = {}, _customAttributes = {}) {
-    const processedError = this.processAxiosError(error);
+  static logApiClientError(error = {}, _customAttributes = {}) {
+    const processedError = this.processApiClientError(error);
     const { messagePrefix, ...customAttributes } = _customAttributes;
     const {
       errorType,

--- a/src/NewRelicLoggingService.js
+++ b/src/NewRelicLoggingService.js
@@ -18,18 +18,22 @@ function fixErrorLength(error) {
 
 class NewRelicLoggingService {
   static logInfo(message, customAttributes = {}) {
+    /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development') {
-      console.log(message); // eslint-disable-line
+      console.log(message, customAttributes); // eslint-disable-line
     }
+    /* istanbul ignore else */
     if (window && typeof window.newrelic !== 'undefined') {
       window.newrelic.addPageAction('INFO', Object.assign({}, { message }, customAttributes));
     }
   }
 
   static logError(error, customAttributes) {
+    /* istanbul ignore next */
     if (process.env.NODE_ENV === 'development') {
       console.error(error, customAttributes); // eslint-disable-line
     }
+    /* istanbul ignore else */
     if (window && typeof window.newrelic !== 'undefined') {
       // Note: customProperties are not sent.  Presumably High-Security Mode is being used.
       window.newrelic.noticeError(fixErrorLength(error), customAttributes);

--- a/src/NewRelicLoggingService.test.js
+++ b/src/NewRelicLoggingService.test.js
@@ -54,7 +54,94 @@ describe('logError', () => {
   });
 });
 
-describe('logAPIErrorResponse', () => {
+describe('processAxiosError', () => {
+  it('will process an empty object', () => {
+    expect(NewRelicLoggingService.processAxiosError())
+      .toEqual({
+        errorType: 'api-request-config-error',
+        errorData: '',
+      });
+  });
+  it('will process a poorly formed axios response object', () => {
+    expect(NewRelicLoggingService.processAxiosError({
+      request: {},
+      response: {},
+      config: {},
+    })).toEqual({
+      errorType: 'api-response-error',
+      errorData: '',
+      errorStatus: '',
+      errorUrl: '',
+    });
+  });
+  it('will process a poorly formed axios request object', () => {
+    expect(NewRelicLoggingService.processAxiosError({
+      request: {},
+      config: {},
+    })).toEqual({
+      errorType: 'api-request-error',
+      errorData: '',
+      errorStatus: '',
+      errorUrl: '',
+      errorMethod: '',
+    });
+  });
+  it('will process an axios request object', () => {
+    expect(NewRelicLoggingService.processAxiosError({
+      request: {
+        responseText: 'Hello',
+        responseURL: 'http://edx.org',
+        status: 400,
+      },
+      config: {
+        method: 'GET',
+        url: 'http://edx.org',
+      },
+    })).toEqual({
+      errorType: 'api-request-error',
+      errorData: 'Hello',
+      errorStatus: 400,
+      errorUrl: 'http://edx.org',
+      errorMethod: 'GET',
+    });
+  });
+  it('will process an axios response object', () => {
+    expect(NewRelicLoggingService.processAxiosError({
+      response: {
+        data: 'Hello',
+        status: 400,
+        config: {
+          method: 'GET',
+          url: 'http://edx.org',
+        },
+      },
+    })).toEqual({
+      errorType: 'api-response-error',
+      errorData: JSON.stringify('Hello'),
+      errorStatus: 400,
+      errorUrl: 'http://edx.org',
+    });
+  });
+  it('will process an axios response object with HTML data in it', () => {
+    expect(NewRelicLoggingService.processAxiosError({
+      response: {
+        data: '<!DOCTYPE html><html>Hi</html>',
+        status: 400,
+        config: {
+          method: 'GET',
+          url: 'http://edx.org',
+        },
+      },
+    })).toEqual({
+      errorType: 'api-response-error',
+      errorData: '<Response is HTML>',
+      errorStatus: 400,
+      errorUrl: 'http://edx.org',
+    });
+  });
+});
+
+describe('logAxiosError', () => {
   beforeEach(() => {
     global.newrelic.noticeError.mockReset();
     global.newrelic.addPageAction.mockReset();
@@ -71,16 +158,16 @@ describe('logAPIErrorResponse', () => {
         method: 'get',
       },
     };
-    const message = `${error.request.status} ${error.config.method} ${error.request.responseURL} ${error.request.responseText}`;
+
     const expectedAttributes = {
-      message: `API request failed: ${message}`,
+      message: 'API request failed: 400 get http://example.com Very bad request',
       errorType: 'api-request-error',
       errorStatus: error.request.status,
       errorMethod: error.config.method,
       errorUrl: error.request.responseURL,
       errorData: error.request.responseText,
     };
-    NewRelicLoggingService.logAPIErrorResponse(error);
+    NewRelicLoggingService.logAxiosError(error);
     expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', expectedAttributes);
   });
 
@@ -96,8 +183,8 @@ describe('logAPIErrorResponse', () => {
         },
       },
     };
-    const message = `${error.response.status} ${error.response.config.url} ${JSON.stringify(error.response.data)}`;
-    const expectedError = new Error(`API request failed: ${message}`);
+    const message = 'API request failed: 500 http://example.com {"detail":"Very bad request"}';
+    const expectedError = new Error(message);
     const expectedAttributes = {
       errorType: 'api-response-error',
       errorStatus: error.response.status,
@@ -105,7 +192,7 @@ describe('logAPIErrorResponse', () => {
       errorData: JSON.stringify(error.response.data),
       test: 'custom',
     };
-    NewRelicLoggingService.logAPIErrorResponse(error, { test: 'custom' });
+    NewRelicLoggingService.logAxiosError(error, { test: 'custom' });
     expect(global.newrelic.noticeError).toHaveBeenCalledWith(expectedError, expectedAttributes);
   });
 
@@ -116,15 +203,15 @@ describe('logAPIErrorResponse', () => {
         data: '<!DOCTYPE html><html lang="en"><body></body></html>',
       },
     };
-    const message = `${error.response.status}  `;
-    const expectedError = new Error(`API request failed: ${message}`);
+    const message = 'API request failed: 500  <Response is HTML>';
+    const expectedError = new Error(message);
     const expectedAttributes = {
       errorType: 'api-response-error',
       errorStatus: error.response.status,
       errorUrl: '',
-      errorData: '',
+      errorData: '<Response is HTML>',
     };
-    NewRelicLoggingService.logAPIErrorResponse(error);
+    NewRelicLoggingService.logAxiosError(error);
     expect(global.newrelic.noticeError).toHaveBeenCalledWith(expectedError, expectedAttributes);
   });
 });

--- a/src/NewRelicLoggingService.test.js
+++ b/src/NewRelicLoggingService.test.js
@@ -54,16 +54,16 @@ describe('logError', () => {
   });
 });
 
-describe('processAxiosError', () => {
+describe('processApiClientError', () => {
   it('will process an empty object', () => {
-    expect(NewRelicLoggingService.processAxiosError())
+    expect(NewRelicLoggingService.processApiClientError())
       .toEqual({
         errorType: 'api-request-config-error',
         errorData: '',
       });
   });
   it('will process a poorly formed axios response object', () => {
-    expect(NewRelicLoggingService.processAxiosError({
+    expect(NewRelicLoggingService.processApiClientError({
       request: {},
       response: {},
       config: {},
@@ -75,7 +75,7 @@ describe('processAxiosError', () => {
     });
   });
   it('will process a poorly formed axios request object', () => {
-    expect(NewRelicLoggingService.processAxiosError({
+    expect(NewRelicLoggingService.processApiClientError({
       request: {},
       config: {},
     })).toEqual({
@@ -87,7 +87,7 @@ describe('processAxiosError', () => {
     });
   });
   it('will process an axios request object', () => {
-    expect(NewRelicLoggingService.processAxiosError({
+    expect(NewRelicLoggingService.processApiClientError({
       request: {
         responseText: 'Hello',
         responseURL: 'http://edx.org',
@@ -106,7 +106,7 @@ describe('processAxiosError', () => {
     });
   });
   it('will process an axios response object', () => {
-    expect(NewRelicLoggingService.processAxiosError({
+    expect(NewRelicLoggingService.processApiClientError({
       response: {
         data: 'Hello',
         status: 400,
@@ -123,7 +123,7 @@ describe('processAxiosError', () => {
     });
   });
   it('will process an axios response object with HTML data in it', () => {
-    expect(NewRelicLoggingService.processAxiosError({
+    expect(NewRelicLoggingService.processApiClientError({
       response: {
         data: '<!DOCTYPE html><html>Hi</html>',
         status: 400,
@@ -141,7 +141,7 @@ describe('processAxiosError', () => {
   });
 });
 
-describe('logAxiosError', () => {
+describe('logApiClientError', () => {
   beforeEach(() => {
     global.newrelic.noticeError.mockReset();
     global.newrelic.addPageAction.mockReset();
@@ -167,7 +167,7 @@ describe('logAxiosError', () => {
       errorUrl: error.request.responseURL,
       errorData: error.request.responseText,
     };
-    NewRelicLoggingService.logAxiosError(error);
+    NewRelicLoggingService.logApiClientError(error);
     expect(global.newrelic.addPageAction).toHaveBeenCalledWith('INFO', expectedAttributes);
   });
 
@@ -192,7 +192,7 @@ describe('logAxiosError', () => {
       errorData: JSON.stringify(error.response.data),
       test: 'custom',
     };
-    NewRelicLoggingService.logAxiosError(error, { test: 'custom' });
+    NewRelicLoggingService.logApiClientError(error, { test: 'custom' });
     expect(global.newrelic.noticeError).toHaveBeenCalledWith(expectedError, expectedAttributes);
   });
 
@@ -211,7 +211,7 @@ describe('logAxiosError', () => {
       errorUrl: '',
       errorData: '<Response is HTML>',
     };
-    NewRelicLoggingService.logAxiosError(error);
+    NewRelicLoggingService.logApiClientError(error);
     expect(global.newrelic.noticeError).toHaveBeenCalledWith(expectedError, expectedAttributes);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
 import NewRelicLoggingService from './NewRelicLoggingService';
 import {
   configureLoggingService,
-  logAPIErrorResponse,
+  logAxiosError,
+  processAxiosError,
   logInfo,
   logError,
 } from './logging';
 
 export {
   configureLoggingService,
-  logAPIErrorResponse,
+  logAxiosError,
+  processAxiosError,
   logInfo,
   logError,
   NewRelicLoggingService,

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
 import NewRelicLoggingService from './NewRelicLoggingService';
 import {
   configureLoggingService,
-  logAxiosError,
-  processAxiosError,
+  logApiClientError,
+  processApiClientError,
   logInfo,
   logError,
 } from './logging';
 
 export {
   configureLoggingService,
-  logAxiosError,
-  processAxiosError,
+  logApiClientError,
+  processApiClientError,
   logInfo,
   logError,
   NewRelicLoggingService,

--- a/src/logging.js
+++ b/src/logging.js
@@ -19,7 +19,7 @@ function configureLoggingService(newLoggingService) {
   if (!newLoggingService) {
     throw Error('The loggingService is required.');
   }
-  ensureLoggingServiceAPI(newLoggingService, 'logAPIErrorResponse');
+  ensureLoggingServiceAPI(newLoggingService, 'logAxiosError');
   ensureLoggingServiceAPI(newLoggingService, 'logInfo');
   ensureLoggingServiceAPI(newLoggingService, 'logError');
   loggingService = newLoggingService;
@@ -44,13 +44,18 @@ function logError(error, customAttributes) {
   return getLoggingService().logError(error, customAttributes);
 }
 
-function logAPIErrorResponse(error, customAttributes) {
-  return getLoggingService().logAPIErrorResponse(error, customAttributes);
+function logAxiosError(error, customAttributes) {
+  return getLoggingService().logAxiosError(error, customAttributes);
+}
+
+function processAxiosError(error) {
+  return getLoggingService().processAxiosError(error);
 }
 
 export {
   configureLoggingService,
-  logAPIErrorResponse,
+  logAxiosError,
+  processAxiosError,
   logInfo,
   logError,
   resetLoggingService,

--- a/src/logging.js
+++ b/src/logging.js
@@ -36,8 +36,8 @@ function getLoggingService() {
   return loggingService;
 }
 
-function logInfo(message) {
-  return getLoggingService().logInfo(message);
+function logInfo(message, customAttributes) {
+  return getLoggingService().logInfo(message, customAttributes);
 }
 
 function logError(error, customAttributes) {

--- a/src/logging.js
+++ b/src/logging.js
@@ -19,7 +19,7 @@ function configureLoggingService(newLoggingService) {
   if (!newLoggingService) {
     throw Error('The loggingService is required.');
   }
-  ensureLoggingServiceAPI(newLoggingService, 'logAxiosError');
+  ensureLoggingServiceAPI(newLoggingService, 'logApiClientError');
   ensureLoggingServiceAPI(newLoggingService, 'logInfo');
   ensureLoggingServiceAPI(newLoggingService, 'logError');
   loggingService = newLoggingService;
@@ -44,18 +44,18 @@ function logError(error, customAttributes) {
   return getLoggingService().logError(error, customAttributes);
 }
 
-function logAxiosError(error, customAttributes) {
-  return getLoggingService().logAxiosError(error, customAttributes);
+function logApiClientError(error, customAttributes) {
+  return getLoggingService().logApiClientError(error, customAttributes);
 }
 
-function processAxiosError(error) {
-  return getLoggingService().processAxiosError(error);
+function processApiClientError(error) {
+  return getLoggingService().processApiClientError(error);
 }
 
 export {
   configureLoggingService,
-  logAxiosError,
-  processAxiosError,
+  logApiClientError,
+  processApiClientError,
   logInfo,
   logError,
   resetLoggingService,

--- a/src/logging.test.js
+++ b/src/logging.test.js
@@ -2,8 +2,8 @@ import NewRelicLoggingService from './NewRelicLoggingService';
 
 import {
   configureLoggingService,
-  logAxiosError,
-  processAxiosError,
+  logApiClientError,
+  processApiClientError,
   logInfo,
   logError,
   resetLoggingService,
@@ -22,7 +22,7 @@ describe('configureLoggingService', () => {
 
   it('fails when loggingService has invalid API', () => {
     expect(() => configureLoggingService({}))
-      .toThrowError(new Error('The loggingService API must have a logAxiosError function.'));
+      .toThrowError(new Error('The loggingService API must have a logApiClientError function.'));
   });
 });
 
@@ -52,22 +52,22 @@ describe('configured logging service', () => {
     });
   });
 
-  describe('logAxiosError', () => {
+  describe('logApiClientError', () => {
     it('passes call through to NewRelicLoggingService', () => {
       const mockStatic = jest.fn();
-      NewRelicLoggingService.logAxiosError = mockStatic.bind(NewRelicLoggingService);
+      NewRelicLoggingService.logApiClientError = mockStatic.bind(NewRelicLoggingService);
 
-      logAxiosError(arg1, arg2);
+      logApiClientError(arg1, arg2);
       expect(mockStatic).toHaveBeenCalledWith(arg1, arg2);
     });
   });
 
-  describe('processAxiosError', () => {
+  describe('processApiClientError', () => {
     it('passes call through to NewRelicLoggingService', () => {
       const mockStatic = jest.fn();
-      NewRelicLoggingService.processAxiosError = mockStatic.bind(NewRelicLoggingService);
+      NewRelicLoggingService.processApiClientError = mockStatic.bind(NewRelicLoggingService);
 
-      processAxiosError(arg1);
+      processApiClientError(arg1);
       expect(mockStatic).toHaveBeenCalledWith(arg1);
     });
   });
@@ -92,9 +92,9 @@ describe('test failures when logging service is not configured', () => {
     });
   });
 
-  describe('logAxiosError', () => {
+  describe('logApiClientError', () => {
     it('throws an error', () => {
-      expect(() => logAxiosError(arg1, arg2))
+      expect(() => logApiClientError(arg1, arg2))
         .toThrowError(new Error('You must first configure the loggingService.'));
     });
   });

--- a/src/logging.test.js
+++ b/src/logging.test.js
@@ -36,8 +36,8 @@ describe('configured logging service', () => {
       const mockStatic = jest.fn();
       NewRelicLoggingService.logInfo = mockStatic.bind(NewRelicLoggingService);
 
-      logInfo(arg1);
-      expect(mockStatic).toHaveBeenCalledWith(arg1);
+      logInfo(arg1, arg2);
+      expect(mockStatic).toHaveBeenCalledWith(arg1, arg2);
     });
   });
 

--- a/src/logging.test.js
+++ b/src/logging.test.js
@@ -2,7 +2,8 @@ import NewRelicLoggingService from './NewRelicLoggingService';
 
 import {
   configureLoggingService,
-  logAPIErrorResponse,
+  logAxiosError,
+  processAxiosError,
   logInfo,
   logError,
   resetLoggingService,
@@ -21,7 +22,7 @@ describe('configureLoggingService', () => {
 
   it('fails when loggingService has invalid API', () => {
     expect(() => configureLoggingService({}))
-      .toThrowError(new Error('The loggingService API must have a logAPIErrorResponse function.'));
+      .toThrowError(new Error('The loggingService API must have a logAxiosError function.'));
   });
 });
 
@@ -51,13 +52,23 @@ describe('configured logging service', () => {
     });
   });
 
-  describe('logAPIErrorResponse', () => {
+  describe('logAxiosError', () => {
     it('passes call through to NewRelicLoggingService', () => {
       const mockStatic = jest.fn();
-      NewRelicLoggingService.logAPIErrorResponse = mockStatic.bind(NewRelicLoggingService);
+      NewRelicLoggingService.logAxiosError = mockStatic.bind(NewRelicLoggingService);
 
-      logAPIErrorResponse(arg1, arg2);
+      logAxiosError(arg1, arg2);
       expect(mockStatic).toHaveBeenCalledWith(arg1, arg2);
+    });
+  });
+
+  describe('processAxiosError', () => {
+    it('passes call through to NewRelicLoggingService', () => {
+      const mockStatic = jest.fn();
+      NewRelicLoggingService.processAxiosError = mockStatic.bind(NewRelicLoggingService);
+
+      processAxiosError(arg1);
+      expect(mockStatic).toHaveBeenCalledWith(arg1);
     });
   });
 });
@@ -81,9 +92,9 @@ describe('test failures when logging service is not configured', () => {
     });
   });
 
-  describe('logAPIErrorResponse', () => {
+  describe('logAxiosError', () => {
     it('throws an error', () => {
-      expect(() => logAPIErrorResponse(arg1, arg2))
+      expect(() => logAxiosError(arg1, arg2))
         .toThrowError(new Error('You must first configure the loggingService.'));
     });
   });


### PR DESCRIPTION
Splits logging and processing of axios errors apart into two functions. Errors that do not contain a response object are still use logInfo instead of logError. Custom attributes can be supplied to the error and a custom messagePrefix will be prepended to the error message.

BREAKING CHANGE: logAPIErrorResponse(error, customAttrs) is renamed to logAxiosError(error, customAttrs). It uses processAxiosError which clients can also leverage to normalize axios error objects. logAxiosError will take a messagePrefix specified in customAttrs and prepend that to error messages.