### PR TITLE
fix: add alias for logAPIErrorResponse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,10 +21,10 @@ To configure the logging service::
 
 To use the configured logging service::
 
-    import { logAPIErrorResponse, logInfo, logError } from '@edx/frontend-logging';
+    import { logApiClientError, logInfo, logError } from '@edx/frontend-logging';
 
     logInfo(message);
-    logAPIErrorResponse(e);  // handles errors or axios error responses
+    logApiClientError(e, customAttributes);  // handles errors or axios error responses
     logError(e);
 
 NewRelicLoggingService
@@ -32,9 +32,9 @@ NewRelicLoggingService
 
 The NewRelicLoggingService is a concrete implementation of the logging service interface that sends messages to NewRelic that can be seen in NewRelic Browser and NewRelic Insights. When in development mode, all messages will instead be sent to the console.
 
-When you use ``logError`` or ``logAPIErrorResponse``, your errors will appear under "JS errors" for your Browser application.
+When you use ``logError`` or ``logApiClientError``, your errors will appear under "JS errors" for your Browser application.
 
-Additionally, when you use `logAPIErrorResponse`, you get some additional custom metrics for Axios error responses. To see those details, you can use a New Relic Insights query like the following::
+Additionally, when you use `logApiClientError`, you get some additional custom metrics for Axios error responses. To see those details, you can use a New Relic Insights query like the following::
 
     SELECT * from JavaScriptError WHERE errorStatus is not null SINCE 10 days ago
 

--- a/src/NewRelicLoggingService.js
+++ b/src/NewRelicLoggingService.js
@@ -114,6 +114,11 @@ class NewRelicLoggingService {
         break;
     }
   }
+
+  /* istanbul ignore next */
+  static logAPIErrorResponse(error, customAttributes) {
+    this.logApiClientError(error, customAttributes);
+  }
 }
 
 export default NewRelicLoggingService;

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import NewRelicLoggingService from './NewRelicLoggingService';
 import {
   configureLoggingService,
   logApiClientError,
+  logAPIErrorResponse,
   processApiClientError,
   logInfo,
   logError,
@@ -10,6 +11,7 @@ import {
 export {
   configureLoggingService,
   logApiClientError,
+  logAPIErrorResponse,
   processApiClientError,
   logInfo,
   logError,

--- a/src/logging.js
+++ b/src/logging.js
@@ -20,6 +20,7 @@ function configureLoggingService(newLoggingService) {
     throw Error('The loggingService is required.');
   }
   ensureLoggingServiceAPI(newLoggingService, 'logApiClientError');
+  ensureLoggingServiceAPI(newLoggingService, 'logAPIErrorResponse');
   ensureLoggingServiceAPI(newLoggingService, 'logInfo');
   ensureLoggingServiceAPI(newLoggingService, 'logError');
   loggingService = newLoggingService;
@@ -48,6 +49,10 @@ function logApiClientError(error, customAttributes) {
   return getLoggingService().logApiClientError(error, customAttributes);
 }
 
+function logAPIErrorResponse(error, customAttributes) {
+  return getLoggingService().logAPIErrorResponse(error, customAttributes);
+}
+
 function processApiClientError(error) {
   return getLoggingService().processApiClientError(error);
 }
@@ -56,6 +61,7 @@ export {
   configureLoggingService,
   logApiClientError,
   processApiClientError,
+  logAPIErrorResponse,
   logInfo,
   logError,
   resetLoggingService,

--- a/src/logging.test.js
+++ b/src/logging.test.js
@@ -4,6 +4,7 @@ import {
   configureLoggingService,
   logApiClientError,
   processApiClientError,
+  logAPIErrorResponse,
   logInfo,
   logError,
   resetLoggingService,
@@ -58,6 +59,16 @@ describe('configured logging service', () => {
       NewRelicLoggingService.logApiClientError = mockStatic.bind(NewRelicLoggingService);
 
       logApiClientError(arg1, arg2);
+      expect(mockStatic).toHaveBeenCalledWith(arg1, arg2);
+    });
+  });
+
+  describe('logAPIErrorResponse', () => {
+    it('passes call through to NewRelicLoggingService', () => {
+      const mockStatic = jest.fn();
+      NewRelicLoggingService.logAPIErrorResponse = mockStatic.bind(NewRelicLoggingService);
+
+      logAPIErrorResponse(arg1, arg2);
       expect(mockStatic).toHaveBeenCalledWith(arg1, arg2);
     });
   });


### PR DESCRIPTION
Some problems arise in MFEs that include other packages expecting the older version of frontend logging. Adding an alias to alieviate update pain.