### PR TITLE
feat: added support to set version dynamically based on the release

### DIFF
--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -41,8 +41,8 @@ class DatadogLoggingService extends NewRelicLoggingService {
 
     const datadogVersion = process.env.DATADOG_VERSION || process.env.APP_VERSION || '1.0.0';
     datadogRum.init({
-      applicationId: process.env.DATADOG_APPLICATION_ID || '',
-      clientToken: process.env.DATADOG_CLIENT_TOKEN || '',
+      applicationId: process.env.DATADOG_APPLICATION_ID,
+      clientToken: process.env.DATADOG_CLIENT_TOKEN,
       site: process.env.DATADOG_SITE || '',
       service: process.env.DATADOG_SERVICE || '',
       env: process.env.DATADOG_ENV || '',
@@ -55,7 +55,7 @@ class DatadogLoggingService extends NewRelicLoggingService {
       defaultPrivacyLevel: 'mask-user-input',
     });
     datadogLogs.init({
-      clientToken: process.env.DATADOG_CLIENT_TOKEN || '',
+      clientToken: process.env.DATADOG_CLIENT_TOKEN,
       site: process.env.DATADOG_SITE || '',
       env: process.env.DATADOG_ENV || '',
       forwardErrorsToLogs: true,

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -28,6 +28,17 @@ class DatadogLoggingService extends NewRelicLoggingService {
   }
 
   initialize() {
+    const requiredDatadogConfig = [
+      process.env.DATADOG_APPLICATION_ID,
+      process.env.DATADOG_CLIENT_TOKEN,
+    ];
+    const hasRequiredDatadogConfig = requiredDatadogConfig.every(value => !!value);
+
+    // Do not attempt to initialize Datadog if required config settings are not supplied.
+    if (!hasRequiredDatadogConfig) {
+      return;
+    }
+
     const datadogVersion = process.env.DATADOG_VERSION || process.env.APP_VERSION || '1.0.0';
     datadogRum.init({
       applicationId: process.env.DATADOG_APPLICATION_ID || '',

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -27,19 +27,8 @@ class DatadogLoggingService extends NewRelicLoggingService {
     this.initialize();
   }
 
-  async initialize() {
-    let datadogVersion = process.env.DATADOG_VERSION || '1.0.0';
-    try {
-      const response = await fetch('version.json');
-      if (response.ok) {
-        const data = await response.json();
-        if (data?.commit) {
-          datadogVersion = data.commit;
-        }
-      }
-    } catch (error) {
-      console.error('Version File Not Found');
-    }
+  initialize() {
+    const datadogVersion = process.env.DATADOG_VERSION || process.env.APP_VERSION || '1.0.0';
     datadogRum.init({
       applicationId: process.env.DATADOG_APPLICATION_ID || '',
       clientToken: process.env.DATADOG_CLIENT_TOKEN || '',

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -27,14 +27,26 @@ class DatadogLoggingService extends NewRelicLoggingService {
     this.initialize();
   }
 
-  initialize() {
+  async initialize() {
+    let datadogVersion = process.env.DATADOG_VERSION;
+    try {
+      const response = await fetch('version.json');
+      if (response.ok) {
+        const data = await response.json();
+        if (data?.commit) {
+          datadogVersion = data.commit;
+        }
+      }
+    } catch (error) {
+      console.error('Version File Not Found');
+    }
     datadogRum.init({
       applicationId: process.env.DATADOG_APPLICATION_ID,
       clientToken: process.env.DATADOG_CLIENT_TOKEN,
       site: process.env.DATADOG_SITE,
       service: process.env.DATADOG_SERVICE,
       env: process.env.DATADOG_ENV,
-      version: process.env.DATADOG_VERSION,
+      version: datadogVersion,
       sessionSampleRate: parseInt(process.env.DATADOG_SESSION_SAMPLE_RATE || 0, 10),
       sessionReplaySampleRate: parseInt(process.env.DATADOG_SESSION_REPLAY_SAMPLE_RATE || 0, 10),
       trackUserInteractions: true,

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -28,7 +28,7 @@ class DatadogLoggingService extends NewRelicLoggingService {
   }
 
   async initialize() {
-    let datadogVersion = process.env.DATADOG_VERSION;
+    let datadogVersion = process.env.DATADOG_VERSION || '1.0.0';
     try {
       const response = await fetch('version.json');
       if (response.ok) {
@@ -41,11 +41,11 @@ class DatadogLoggingService extends NewRelicLoggingService {
       console.error('Version File Not Found');
     }
     datadogRum.init({
-      applicationId: process.env.DATADOG_APPLICATION_ID,
-      clientToken: process.env.DATADOG_CLIENT_TOKEN,
-      site: process.env.DATADOG_SITE,
-      service: process.env.DATADOG_SERVICE,
-      env: process.env.DATADOG_ENV,
+      applicationId: process.env.DATADOG_APPLICATION_ID || '',
+      clientToken: process.env.DATADOG_CLIENT_TOKEN || '',
+      site: process.env.DATADOG_SITE || '',
+      service: process.env.DATADOG_SERVICE || '',
+      env: process.env.DATADOG_ENV || '',
       version: datadogVersion,
       sessionSampleRate: parseInt(process.env.DATADOG_SESSION_SAMPLE_RATE || 0, 10),
       sessionReplaySampleRate: parseInt(process.env.DATADOG_SESSION_REPLAY_SAMPLE_RATE || 0, 10),
@@ -55,12 +55,13 @@ class DatadogLoggingService extends NewRelicLoggingService {
       defaultPrivacyLevel: 'mask-user-input',
     });
     datadogLogs.init({
-      clientToken: process.env.DATADOG_CLIENT_TOKEN,
-      site: process.env.DATADOG_SITE,
-      env: process.env.DATADOG_ENV,
+      clientToken: process.env.DATADOG_CLIENT_TOKEN || '',
+      site: process.env.DATADOG_SITE || '',
+      env: process.env.DATADOG_ENV || '',
       forwardErrorsToLogs: true,
       sessionSampleRate: parseInt(process.env.DATADOG_LOGS_SESSION_SAMPLE_RATE || 0, 10),
-      service: process.env.DATADOG_SERVICE,
+      service: process.env.DATADOG_SERVICE || '',
+      version: datadogVersion,
     });
   }
 


### PR DESCRIPTION
Added support to read and set version of datadog RUM. Version is read from `process.env.APP_VERSION`, which is recently introduced in [[tubular](https://github.com/edx/tubular/pull/2)].

[Ticket](https://github.com/edx/edx-arch-experiments/issues/634)