### PR TITLE
feat: add beforeSend to RUM init

### DIFF
--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -27,8 +27,10 @@ class DatadogLoggingService extends NewRelicLoggingService {
     this.initialize();
   }
 
-  // to read more about the use cases for beforeSend
+  // to read more about the use cases for beforeSend, refer to the documentation:
   // https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/?tab=event#event-and-context-structure
+  // (e.g., discarding frontend errors matching the optional `IGNORED_ERROR_REGEX` configuration,
+  // currently implemented in `logError` below).
   beforeSend() {
     // common/shared logic across all MFEs
     return true;

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -27,6 +27,13 @@ class DatadogLoggingService extends NewRelicLoggingService {
     this.initialize();
   }
 
+  // to read more about the use cases for beforeSend
+  // https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/?tab=event#event-and-context-structure
+  beforeSend() {
+    // common/shared logic across all MFEs
+    return true;
+  }
+
   initialize() {
     const requiredDatadogConfig = [
       process.env.DATADOG_APPLICATION_ID,
@@ -42,6 +49,7 @@ class DatadogLoggingService extends NewRelicLoggingService {
     const datadogVersion = process.env.DATADOG_VERSION || process.env.APP_VERSION || '1.0.0';
     datadogRum.init({
       applicationId: process.env.DATADOG_APPLICATION_ID,
+      beforeSend: this.beforeSend,
       clientToken: process.env.DATADOG_CLIENT_TOKEN,
       site: process.env.DATADOG_SITE || '',
       service: process.env.DATADOG_SERVICE || '',


### PR DESCRIPTION
This PR is to resolve an issue posted in [edx-arch-experiment](https://github.com/edx/edx-arch-experiments/issues/698). The goal is to allow for MFEs to edit or customize their event attributes before sending them to Datadog, so a suggested solution was to use the built-in `beforeSend` method from Datadog ([documentation](https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration/?tab=npm#modify-the-content-of-a-rum-event)). 

An example of how this is being used can be found in [an edx-internal PR for Profile MFE](https://github.com/edx/edx-internal/pull/11307) that aims to clean usernames from the URL strings.

This PR also allows for the beforeSend method to be used more generally across all MFEs if desired. 