### PR TITLE
feat: allow stricter masking

### DIFF
--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -62,7 +62,7 @@ class DatadogLoggingService extends NewRelicLoggingService {
       trackUserInteractions: true,
       trackResources: true,
       trackLongTasks: true,
-      defaultPrivacyLevel: 'mask-user-input',
+      defaultPrivacyLevel: process.env.DATADOG_PRIVACY_LEVEL || 'mask-user-input',
     });
     datadogLogs.init({
       clientToken: process.env.DATADOG_CLIENT_TOKEN,


### PR DESCRIPTION
For some applications, we want to mask all text and images, because non-input text sometimes contains PII. Allows setting this by environment variable.