### PR TITLE
refactor: remove Node version logging from DatadogLoggingService

### DIFF
--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -81,15 +81,6 @@ class DatadogLoggingService extends NewRelicLoggingService {
     this.setCustomAttribute('react.version', reactVersion);
   }
 
-  addNodeVersion() {
-    try {
-      const nodeVersion = process.version || 'unknown';
-      this.setCustomAttribute('node.version', nodeVersion);
-    } catch (error) {
-      sendError(error);
-    }
-  }
-
   initialize() {
     const requiredDatadogConfig = [
       process.env.DATADOG_APPLICATION_ID,
@@ -134,7 +125,6 @@ class DatadogLoggingService extends NewRelicLoggingService {
     });
 
     this.addReactVersion();
-    this.addNodeVersion();
   }
 
   logInfo(infoStringOrErrorObject, customAttributes = {}) {

--- a/src/DatadogLoggingService.test.js
+++ b/src/DatadogLoggingService.test.js
@@ -283,7 +283,7 @@ describe('DatadogLoggingService', () => {
       datadogLogs.setGlobalContextProperty.mockReset();
     });
 
-    it('adds React and Node version metadata during initialization', () => {
+    it('adds React version metadata during initialization', () => {
       process.env.DATADOG_APPLICATION_ID = 'test-app-id';
       process.env.DATADOG_CLIENT_TOKEN = 'test-client-token';
 
@@ -295,21 +295,10 @@ describe('DatadogLoggingService', () => {
       expect(reactVersionCalls.length).toBeGreaterThan(0);
       expect(reactVersionCalls[0][1]).toBeDefined();
 
-      const nodeVersionCalls = datadogRum.setGlobalContextProperty.mock.calls.filter(
-        call => call[0] === 'node.version',
-      );
-      expect(nodeVersionCalls.length).toBeGreaterThan(0);
-      expect(nodeVersionCalls[0][1]).toBeDefined();
-
       const reactVersionLogsCalls = datadogLogs.setGlobalContextProperty.mock.calls.filter(
         call => call[0] === 'react.version',
       );
       expect(reactVersionLogsCalls.length).toBeGreaterThan(0);
-
-      const nodeVersionLogsCalls = datadogLogs.setGlobalContextProperty.mock.calls.filter(
-        call => call[0] === 'node.version',
-      );
-      expect(nodeVersionLogsCalls.length).toBeGreaterThan(0);
 
       delete process.env.DATADOG_APPLICATION_ID;
       delete process.env.DATADOG_CLIENT_TOKEN;


### PR DESCRIPTION
### Description

The addNodeVersion() method is trying to use process.version, but this code runs in the browser where process.version is not available (it's a Node.js runtime property). In browser environments, process.version is typically set during the build process by webpack or similar bundlers, but it represents the Node version used during the build, not at runtime.

Since this is a browser-based logging service (using @datadog/browser-rum and @datadog/browser-logs), the Node version won't be available at runtime