### PR TITLE
fix: wire IGNORED_ERROR_REGEX into DataDog RUM/Logs beforeSend to suppress RV widget noise

### DIFF
--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -24,16 +24,21 @@ class DatadogLoggingService extends NewRelicLoggingService {
     super(options);
     const config = options ? options.config : undefined;
     this.ignoredErrorRegexes = config ? config.IGNORED_ERROR_REGEX : undefined;
+    this.beforeSend = this.beforeSend.bind(this);
     this.initialize();
     this.addRUMFeatureFlags();
   }
 
   // to read more about the use cases for beforeSend, refer to the documentation:
   // https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/?tab=event#event-and-context-structure
-  // (e.g., discarding frontend errors matching the optional `IGNORED_ERROR_REGEX` configuration,
-  // currently implemented in `logError` below).
-  beforeSend() {
-    // common/shared logic across all MFEs
+  beforeSend(event) {
+    // Discard RUM error events matching IGNORED_ERROR_REGEX
+    if (event.type === 'error' && this.ignoredErrorRegexes) {
+      const errorMessage = event.error?.message || event.error?.stack || '';
+      if (errorMessage.match(this.ignoredErrorRegexes)) {
+        return false;
+      }
+    }
     return true;
   }
 
@@ -121,6 +126,15 @@ class DatadogLoggingService extends NewRelicLoggingService {
     datadogLogs.init({
       ...commonInitOptions,
       forwardErrorsToLogs: true,
+      beforeSend: (log) => {
+        if (log.status === 'error' && this.ignoredErrorRegexes) {
+          const msg = log.message || '';
+          if (msg.match(this.ignoredErrorRegexes)) {
+            return false;
+          }
+        }
+        return true;
+      },
       sessionSampleRate: parseInt(process.env.DATADOG_LOGS_SESSION_SAMPLE_RATE || 0, 10),
     });
 


### PR DESCRIPTION
## Description

Implement `beforeSend()` filtering in DataDog RUM and Logs to suppress confirmed-safe RV widget injection errors that currently bypass the `IGNORED_ERROR_REGEX` config.

## Root Cause

The `beforeSend()` hook in `DatadogLoggingService.js` is a no-op that always returns `true`. The `IGNORED_ERROR_REGEX` config (added in [edx/edx-internal#14593](https://github.com/edx/edx-internal/pull/14593)) only filters errors going through the explicit `logError()` code path. However, the RV widget errors are thrown as unhandled exceptions and auto-captured by DataDog RUM SDK — they never pass through `logError()`, so the regex filter has no effect on them.

## Errors Suppressed

| Error | Volume | % of Total |
|-------|--------|-----------|
| `RenderFallbackSignal: Render fallback requested by widget` | 860.06k | 35.66% |
| `Error: Monarch is not available` | 208.85k | 8.66% |

## Changes

1. **Bind `this` in constructor** — ensures `beforeSend` has access to `this.ignoredErrorRegexes`
2. **Implement RUM `beforeSend(event)` filtering** — checks `event.error.message` against `IGNORED_ERROR_REGEX` and returns `false` to discard matched errors
3. **Add Logs `beforeSend(log)` filtering** — suppresses the same errors from DataDog Logs (captured via `forwardErrorsToLogs: true`)

## Linked PR

- Config (merged): [edx/edx-internal#14593](https://github.com/edx/edx-internal/pull/14593) — adds `IGNORED_ERROR_REGEX` patterns to `prod_config.yml` and `stage_config.yml`

## Ticket

[LP-915: Bring Frontend service error rate down below 5% [Silence noise]](https://2u-internal.atlassian.net/browse/LP-915)
