### PR TITLE
fix: reconstruct full error string in RUM beforeSend for regex matching

### DIFF
--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -35,8 +35,15 @@ class DatadogLoggingService extends NewRelicLoggingService {
     if (event.type === 'error' && this.ignoredErrorRegexes) {
       const errorMessage = event.error?.message || event.error?.stack || '';
       const errorType = event.error?.type || '';
-      const fullErrorMessage = errorType ? `${errorType}: ${errorMessage}` : errorMessage;
-      if (fullErrorMessage.match(this.ignoredErrorRegexes) || errorMessage.match(this.ignoredErrorRegexes)) {
+
+      if (errorType) {
+        const fullErrorMessage = `${errorType}: ${errorMessage}`;
+        if (fullErrorMessage.match(this.ignoredErrorRegexes)) {
+          return false;
+        }
+      }
+
+      if (errorMessage.match(this.ignoredErrorRegexes)) {
         return false;
       }
     }

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -130,9 +130,7 @@ class DatadogLoggingService extends NewRelicLoggingService {
       beforeSend: (log) => {
         if (log.status === 'error' && this.ignoredErrorRegexes) {
           const msg = log.message || '';
-          const errorType = log.error?.type || '';
-          const fullMsg = errorType ? `${errorType}: ${msg}` : msg;
-          if (fullMsg.match(this.ignoredErrorRegexes) || msg.match(this.ignoredErrorRegexes)) {
+          if (msg.match(this.ignoredErrorRegexes)) {
             return false;
           }
         }

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -32,10 +32,11 @@ class DatadogLoggingService extends NewRelicLoggingService {
   // to read more about the use cases for beforeSend, refer to the documentation:
   // https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/?tab=event#event-and-context-structure
   beforeSend(event) {
-    // Discard RUM error events matching IGNORED_ERROR_REGEX
     if (event.type === 'error' && this.ignoredErrorRegexes) {
       const errorMessage = event.error?.message || event.error?.stack || '';
-      if (errorMessage.match(this.ignoredErrorRegexes)) {
+      const errorType = event.error?.type || '';
+      const fullErrorMessage = errorType ? `${errorType}: ${errorMessage}` : errorMessage;
+      if (fullErrorMessage.match(this.ignoredErrorRegexes) || errorMessage.match(this.ignoredErrorRegexes)) {
         return false;
       }
     }
@@ -129,7 +130,9 @@ class DatadogLoggingService extends NewRelicLoggingService {
       beforeSend: (log) => {
         if (log.status === 'error' && this.ignoredErrorRegexes) {
           const msg = log.message || '';
-          if (msg.match(this.ignoredErrorRegexes)) {
+          const errorType = log.error?.type || '';
+          const fullMsg = errorType ? `${errorType}: ${msg}` : msg;
+          if (fullMsg.match(this.ignoredErrorRegexes) || msg.match(this.ignoredErrorRegexes)) {
             return false;
           }
         }


### PR DESCRIPTION
## Summary

Fix RUM `beforeSend()` error filtering to correctly match `IGNORED_ERROR_REGEX`
patterns against the full error string.

## Problem

After deploying `IGNORED_ERROR_REGEX` config and the `beforeSend()` filtering logic (PR #50), errors from the RV/Monarch widget injection continued appearing in DataDog.

**Root cause:** DataDog RUM SDK separates `event.error.type` and `event.error.message` into distinct fields. Our regex patterns target the combined UI display format (`"RenderFallbackSignal: Render fallback requested by widget"`), but `beforeSend()` was only checking `event.error.message` (which is just `"Render fallback requested by widget"` — without the type prefix). The regex never matched.

## Fix

In the RUM `beforeSend()`, reconstruct the full error string by combining `event.error.type` + `event.error.message` before matching against the regex. Also match against the raw message alone to handle patterns without a type prefix (e.g., `[UCL] Mount failed:...`).
