### PR TITLE
fix: drop ignored errors from Datadog RUM and logs

### DIFF
--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -25,7 +25,6 @@ class DatadogLoggingService extends NewRelicLoggingService {
     const config = options ? options.config : undefined;
     this.ignoredErrorRegexes = config ? config.IGNORED_ERROR_REGEX : undefined;
     this.beforeSend = this.beforeSend.bind(this);
-    this.beforeSendLog = this.beforeSendLog.bind(this);
     this.initialize();
     this.addRUMFeatureFlags();
   }
@@ -63,18 +62,6 @@ class DatadogLoggingService extends NewRelicLoggingService {
     }
 
     // common/shared logic across all MFEs
-    return true;
-  }
-
-  beforeSendLog(log) {
-    if (
-      log
-      && log.status === 'error'
-      && this.getBeforeSendErrorMessages(log).some(message => this.isIgnoredErrorMessage(message))
-    ) {
-      return false;
-    }
-
     return true;
   }
 
@@ -162,7 +149,6 @@ class DatadogLoggingService extends NewRelicLoggingService {
     datadogLogs.init({
       ...commonInitOptions,
       forwardErrorsToLogs: true,
-      beforeSend: this.beforeSendLog,
       sessionSampleRate: parseInt(process.env.DATADOG_LOGS_SESSION_SAMPLE_RATE || 0, 10),
     });
 

--- a/src/DatadogLoggingService.js
+++ b/src/DatadogLoggingService.js
@@ -25,28 +25,56 @@ class DatadogLoggingService extends NewRelicLoggingService {
     const config = options ? options.config : undefined;
     this.ignoredErrorRegexes = config ? config.IGNORED_ERROR_REGEX : undefined;
     this.beforeSend = this.beforeSend.bind(this);
+    this.beforeSendLog = this.beforeSendLog.bind(this);
     this.initialize();
     this.addRUMFeatureFlags();
   }
 
+  isIgnoredErrorMessage(errorMessage) {
+    return !!(
+      this.ignoredErrorRegexes
+      && typeof errorMessage === 'string'
+      && errorMessage.match(this.ignoredErrorRegexes)
+    );
+  }
+
+  getBeforeSendErrorMessages(event, context) {
+    const contextError = context ? context.error : undefined;
+    return [
+      event && event.error && event.error.message,
+      event && event.error && event.error.stack,
+      event && event.message,
+      contextError && contextError.message,
+      contextError && contextError.toString && contextError.toString(),
+    ].filter(message => typeof message === 'string' && message !== '');
+  }
+
   // to read more about the use cases for beforeSend, refer to the documentation:
   // https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/?tab=event#event-and-context-structure
-  beforeSend(event) {
-    if (event.type === 'error' && this.ignoredErrorRegexes) {
-      const errorMessage = event.error?.message || event.error?.stack || '';
-      const errorType = event.error?.type || '';
-
-      if (errorType) {
-        const fullErrorMessage = `${errorType}: ${errorMessage}`;
-        if (fullErrorMessage.match(this.ignoredErrorRegexes)) {
-          return false;
-        }
-      }
-
-      if (errorMessage.match(this.ignoredErrorRegexes)) {
-        return false;
-      }
+  // (e.g., discarding frontend errors matching the optional `IGNORED_ERROR_REGEX` configuration,
+  // also implemented in `logError` below).
+  beforeSend(event, context) {
+    if (
+      event
+      && event.type === 'error'
+      && this.getBeforeSendErrorMessages(event, context).some(message => this.isIgnoredErrorMessage(message))
+    ) {
+      return false;
     }
+
+    // common/shared logic across all MFEs
+    return true;
+  }
+
+  beforeSendLog(log) {
+    if (
+      log
+      && log.status === 'error'
+      && this.getBeforeSendErrorMessages(log).some(message => this.isIgnoredErrorMessage(message))
+    ) {
+      return false;
+    }
+
     return true;
   }
 
@@ -134,15 +162,7 @@ class DatadogLoggingService extends NewRelicLoggingService {
     datadogLogs.init({
       ...commonInitOptions,
       forwardErrorsToLogs: true,
-      beforeSend: (log) => {
-        if (log.status === 'error' && this.ignoredErrorRegexes) {
-          const msg = log.message || '';
-          if (msg.match(this.ignoredErrorRegexes)) {
-            return false;
-          }
-        }
-        return true;
-      },
+      beforeSend: this.beforeSendLog,
       sessionSampleRate: parseInt(process.env.DATADOG_LOGS_SESSION_SAMPLE_RATE || 0, 10),
     });
 
@@ -182,7 +202,7 @@ class DatadogLoggingService extends NewRelicLoggingService {
       Other errors are logged via error API.
     */
     const errorMessage = errorStringOrObject.message || (typeof errorStringOrObject === 'string' ? errorStringOrObject : '');
-    if (this.ignoredErrorRegexes && errorMessage.match(this.ignoredErrorRegexes)) {
+    if (this.isIgnoredErrorMessage(errorMessage)) {
       /* ignored error */
       sendBrowserLog(browserLogNameIgnoredError, errorMessage, allCustomAttributes);
     } else {

--- a/src/DatadogLoggingService.test.js
+++ b/src/DatadogLoggingService.test.js
@@ -48,6 +48,11 @@ const configWithWhitespaceIgnoredErrors = {
 const configWithMissingIgnoredErrors = {
   config: {},
 };
+const configWithRumIgnoredErrors = {
+  config: {
+    IGNORED_ERROR_REGEX: /^(?:RenderFallbackSignal: )?Render fallback requested by widget$|^(?:Error: )?Monarch is not available$/,
+  },
+};
 
 describe('DatadogLoggingService', () => {
   beforeEach(() => {
@@ -199,6 +204,80 @@ describe('DatadogLoggingService', () => {
       const error = new Error('Ignore this error!');
       service.logError(error);
       expect(datadogLogs.logger.error).toHaveBeenCalledWith(error, undefined);
+    });
+  });
+
+  describe('beforeSend', () => {
+    beforeEach(() => {
+      datadogRum.init.mockReset();
+      datadogLogs.init.mockReset();
+    });
+
+    it('drops RUM error events matching ignored error config messages', () => {
+      service = new DatadogLoggingService(configWithRumIgnoredErrors);
+      const rumOptions = datadogRum.init.mock.calls[0][0];
+
+      expect(rumOptions.beforeSend({
+        type: 'error',
+        error: { message: 'Render fallback requested by widget' },
+      })).toBe(false);
+      expect(rumOptions.beforeSend({
+        type: 'error',
+        error: { message: 'RenderFallbackSignal: Render fallback requested by widget' },
+      })).toBe(false);
+      expect(rumOptions.beforeSend({
+        type: 'error',
+        error: { message: 'Monarch is not available' },
+      })).toBe(false);
+      expect(rumOptions.beforeSend({
+        type: 'error',
+        error: { message: 'Error: Monarch is not available' },
+      })).toBe(false);
+    });
+
+    it('drops RUM error events matching ignored context error messages', () => {
+      service = new DatadogLoggingService(configWithRumIgnoredErrors);
+      const rumOptions = datadogRum.init.mock.calls[0][0];
+      const error = new Error('Render fallback requested by widget');
+      error.name = 'RenderFallbackSignal';
+
+      expect(rumOptions.beforeSend({
+        type: 'error',
+        error: { message: 'Unhelpful browser formatted message' },
+      }, { error })).toBe(false);
+    });
+
+    it('drops browser log error events matching ignored error config messages', () => {
+      service = new DatadogLoggingService(configWithRumIgnoredErrors);
+      const logsOptions = datadogLogs.init.mock.calls[0][0];
+
+      expect(logsOptions.beforeSend({
+        status: 'error',
+        message: 'Render fallback requested by widget',
+      })).toBe(false);
+      expect(logsOptions.beforeSend({
+        status: 'error',
+        error: { message: 'Error: Monarch is not available' },
+      })).toBe(false);
+    });
+
+    it('keeps unmatched error events and non-error events', () => {
+      service = new DatadogLoggingService(configWithRumIgnoredErrors);
+      const rumOptions = datadogRum.init.mock.calls[0][0];
+      const logsOptions = datadogLogs.init.mock.calls[0][0];
+
+      expect(rumOptions.beforeSend({
+        type: 'error',
+        error: { message: 'Unexpected application failure' },
+      })).toBe(true);
+      expect(rumOptions.beforeSend({
+        type: 'view',
+        message: 'Render fallback requested by widget',
+      })).toBe(true);
+      expect(logsOptions.beforeSend({
+        status: 'info',
+        message: 'Render fallback requested by widget',
+      })).toBe(true);
     });
   });
 

--- a/src/DatadogLoggingService.test.js
+++ b/src/DatadogLoggingService.test.js
@@ -210,7 +210,6 @@ describe('DatadogLoggingService', () => {
   describe('beforeSend', () => {
     beforeEach(() => {
       datadogRum.init.mockReset();
-      datadogLogs.init.mockReset();
     });
 
     it('drops RUM error events matching ignored error config messages', () => {
@@ -247,24 +246,9 @@ describe('DatadogLoggingService', () => {
       }, { error })).toBe(false);
     });
 
-    it('drops browser log error events matching ignored error config messages', () => {
-      service = new DatadogLoggingService(configWithRumIgnoredErrors);
-      const logsOptions = datadogLogs.init.mock.calls[0][0];
-
-      expect(logsOptions.beforeSend({
-        status: 'error',
-        message: 'Render fallback requested by widget',
-      })).toBe(false);
-      expect(logsOptions.beforeSend({
-        status: 'error',
-        error: { message: 'Error: Monarch is not available' },
-      })).toBe(false);
-    });
-
-    it('keeps unmatched error events and non-error events', () => {
+    it('keeps unmatched RUM error events and non-error events', () => {
       service = new DatadogLoggingService(configWithRumIgnoredErrors);
       const rumOptions = datadogRum.init.mock.calls[0][0];
-      const logsOptions = datadogLogs.init.mock.calls[0][0];
 
       expect(rumOptions.beforeSend({
         type: 'error',
@@ -272,10 +256,6 @@ describe('DatadogLoggingService', () => {
       })).toBe(true);
       expect(rumOptions.beforeSend({
         type: 'view',
-        message: 'Render fallback requested by widget',
-      })).toBe(true);
-      expect(logsOptions.beforeSend({
-        status: 'info',
         message: 'Render fallback requested by widget',
       })).toBe(true);
     });


### PR DESCRIPTION
## Summary
- Apply `IGNORED_ERROR_REGEX` filtering to Datadog RUM `beforeSend` events.
- Apply the same filtering to Datadog browser logs `beforeSend`.
- Reuse one shared ignored-error matcher for explicit `logError`, RUM errors, and forwarded browser logs.
- Add coverage for RV/Monarch noise variants:
  - `RenderFallbackSignal: Render fallback requested by widget`
  - `Render fallback requested by widget`
  - `Error: Monarch is not available`
  - `Monarch is not available`

